### PR TITLE
Changed Readme, tested for Flutter 3 compatibility and updated selection color

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This version of Retro will eventually succeed the current [build that's availabl
 4. ```flutter pub get && flutter run```
 5. That's it! 
 
-_Note: If you want to develop on this, you're going to need an Apple Developer Account_
+_Note: If you want to develop on this, you're going to need a mac as well as an Apple Developer Account (paid or free)_
 
 ## Contributing
 
@@ -55,7 +55,7 @@ This is a list of all the things that are left to complete (there's likely more 
 | Menu Layout | ✅ | ✅ |
 | Music Player functions | 🚧 | 🚧 |
 | Migrate to Android embedding v2 | N/A | ✅ |
-| Migrate to Flutter 3 | 🚧 | 🚧 |
+| Migrate to Flutter 3 | ✅ | ✅ |
 | Splash screen | 🚧 | 🚧 |
 | Dynamic Menu Sizes | 🚧 | 🚧 |
 | Responsive to all screens | 🚧 | 🚧 |

--- a/lib/ipod_menu_widget/ipod_menu_page_widget.dart
+++ b/lib/ipod_menu_widget/ipod_menu_page_widget.dart
@@ -37,8 +37,8 @@ class IPodMenuPageWidget extends StatefulWidget {
         this.selectionColor = selectionColor ??
             LinearGradient(
               colors: [
-                Color(0xFF3BB3EF),
                 Color(0xFF1F7BC4),
+                Color(0xFF3BB3EF),
               ],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,

--- a/lib/ipod_menu_widget/ipod_menu_page_widget.dart
+++ b/lib/ipod_menu_widget/ipod_menu_page_widget.dart
@@ -37,8 +37,8 @@ class IPodMenuPageWidget extends StatefulWidget {
         this.selectionColor = selectionColor ??
             LinearGradient(
               colors: [
-                Color(0xFF0168C7),
-                Color(0xFF39AFDA),
+                Color(0xFF3BB3EF),
+                Color(0xFF1F7BC4),
               ],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,

--- a/lib/ipod_menu_widget/ipod_menu_widget.dart
+++ b/lib/ipod_menu_widget/ipod_menu_widget.dart
@@ -26,8 +26,8 @@ class IPodMenuWidget extends StatefulWidget {
         this.selectionColor = selectionColor ??
             LinearGradient(
               colors: [
-                Color(0xFF3BB3EF),
                 Color(0xFF1F7BC4),
+                Color(0xFF3BB3EF),
               ],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,

--- a/lib/ipod_menu_widget/ipod_menu_widget.dart
+++ b/lib/ipod_menu_widget/ipod_menu_widget.dart
@@ -26,8 +26,8 @@ class IPodMenuWidget extends StatefulWidget {
         this.selectionColor = selectionColor ??
             LinearGradient(
               colors: [
-                Color(0xFF0168C7),
-                Color(0xFF39AFDA),
+                Color(0xFF3BB3EF),
+                Color(0xFF1F7BC4),
               ],
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,


### PR DESCRIPTION
Tested the code with a new flutter 3 installation, everything works as expected. Some warnings about a redundant check that something isn't null, according to a quick google search changing anything isn't required

Updated readme to clarify that a Mac is required (and that a free developer account is enough)

Changed the selection colors to match those on an iPod by taking them from an old image found on Apples Website using archive.org