### PR TITLE
Adding sideloading support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_ID=invalid
 SPOTIFY_REDIRECT_URL=comspotify://co.retromusic

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Retro aims to bring back the iPod Classic experience to iOS and Android. I origi
 
 # Setup
 
-If you'd like to run the app on your own device and compile from the source, you can do so by following the instructions below.
+If you'd like to run the app on your own device you can [sideload](Sideloading.md) it or compile everything from source, you can do so by following the instructions below.
 
 ## Instructions
 

--- a/Sideloading.md
+++ b/Sideloading.md
@@ -1,0 +1,9 @@
+## Sideloading
+Retro does support sideloading, but requires further setup. \
+If properly compiled, the onboarding assistent will ask for a client ID. To obtain one, register at spotify developer (developer.spotify.com/dashboard) and create a new app. Name it what you want, add any description and type 'comspotify://co.retromusic' as redirect url.
+Accept the terms and enable iOS and android support. \
+If you're on iOS make sure to enter the bundle ID you used to sideload your app under iOS app bundles, if you're on android add a package named 'co.retromusic.app2' as well as the following SHA1 key: [tba].\
+Finally enter the client id obtained from spotify into the onboarding assistent. Make sure to avoid typos, as there's currently no way to change the client id afterwards without a full reinstall. Retro should work now (if it doesn't, try restarting the app).
+
+## Technical Information
+To compile a retro build with sideloading support, the cliend ID in '.env' has to be 'invalid'. Else the onboarding assistent won't ask for one. Also, the redirect url should be "comspotify://co.retromusic".

--- a/lib/onboarding/walkthrough.dart
+++ b/lib/onboarding/walkthrough.dart
@@ -1,10 +1,10 @@
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import 'package:retro/main.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class WalkthroughScreen extends StatelessWidget {
   final PageController _controller = PageController();
@@ -363,6 +363,12 @@ class WalkthroughScreen extends StatelessWidget {
                               border: OutlineInputBorder(),
                               hintText: 'Client ID',
                             ),
+                            onChanged: (text) async {
+                              print(text);
+                              final SharedPreferences prefs = await SharedPreferences.getInstance();
+                              prefs.setString('clientID', text);
+                              print(prefs.getString('clientID'));
+                            },
                           ),
                         ],
                       ),

--- a/lib/onboarding/walkthrough.dart
+++ b/lib/onboarding/walkthrough.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import 'package:retro/main.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class WalkthroughScreen extends StatelessWidget {
   final PageController _controller = PageController();
@@ -26,10 +27,12 @@ class WalkthroughScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: PageView(
         controller: _controller,
         children: <Widget>[
           // Insert your walkthrough Widgets here
+
           Container(
             color: Colors.white,
             child: Stack(
@@ -314,7 +317,95 @@ class WalkthroughScreen extends StatelessWidget {
             ),
           ),
 
+          if (dotenv.env['SPOTIFY_CLIENT_ID'] == "invalid") Container( //only show this screen if client id has been set to "invalid"
+            color: Colors.white,
+            child: Stack(
+              children: <Widget>[
+                Align(
+                  alignment: Alignment.topRight,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 50, 10, 0), // Provide some padding from the top-right edge
+                    child: TextButton(
+                      child: Text('Skip', style: TextStyle(color: Colors.blue)),
+                      onPressed: () {
+                        HapticFeedback.mediumImpact();
+                        int lastIndex = 4;  // The index of the last page
+                        _controller.animateToPage(
+                          lastIndex,
+                          duration: Duration(milliseconds: 800), // Define the duration of the animation
+                          curve: Curves.easeInOut, // Define the type of animation
+                        );
+                      },
+                    ),
+                  ),
+                ),
 
+
+                Transform.scale(
+                  scale: 0.7,
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 10, 20, 0), // Provide some padding from the top
+                      child: Column(
+                        children: <Widget>[
+                          Text(
+                            'One last step...',
+                            style: TextStyle(color: Colors.blue, fontSize: 45,),
+                            textAlign: TextAlign.center,
+                          ),
+                          Text(
+                            'Retro detected that it has been sideloaded. To access Spotify features within our app, please provide your own Spotify API keys. Your credentials will only be stored locally and sent to Spotify for authentication purposes.\nEnter the Client ID into the text field below.',
+                            style: TextStyle(color: Colors.blue[200], fontSize: 20,),
+                          ),
+                          TextField(
+                            decoration: InputDecoration(
+                              border: OutlineInputBorder(),
+                              hintText: 'Client ID',
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () {
+                    _controller.previousPage(duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+                    HapticFeedback.mediumImpact();
+                  },
+                  child: Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 50.0, left: 30,), // Adjust the bottom padding as needed
+                      child: Icon(
+                        SFSymbols.arrow_left, // Replace with your desired icon
+                        size: 35, // Adjust the size as needed
+                        color: Color.fromARGB(255, 59, 59, 59), // Adjust the color as needed
+                      ),
+                    ),
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () {
+                    _controller.nextPage(duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+                    HapticFeedback.mediumImpact();
+                  },
+                  child: Align(
+                    alignment: Alignment.bottomRight,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 50.0, right: 30,), // Adjust the bottom padding as needed
+                      child: Icon(
+                        SFSymbols.arrow_right, // Replace with your desired icon
+                        size: 35, // Adjust the size as needed
+                        color: Color.fromARGB(255, 59, 59, 59), // Adjust the color as needed
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
 
 
           Container(

--- a/lib/resources/spotify/spotify_player_provider.dart
+++ b/lib/resources/spotify/spotify_player_provider.dart
@@ -7,7 +7,7 @@ import 'package:retro/music_models/apple_music/song/song_model.dart';
 import 'package:retro/music_models/playback_state/playback_state_model.dart';
 import 'package:spotify_sdk/models/player_state.dart';
 import 'package:spotify_sdk/spotify_sdk.dart';
-
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:retro/resources/resources.dart';
 
 class SpotifyPlayerProvider extends PlayerProvider {
@@ -91,6 +91,8 @@ class SpotifyPlayerProvider extends PlayerProvider {
 
   @override
   Future<bool> connect() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (_clientID == "invalid") _clientID = prefs.getString('clientID');
     final bool isConnected = await SpotifySdk.connectToSpotifyRemote(
         clientId: _clientID!, redirectUrl: _redirectUrl!,);
         

--- a/lib/resources/spotify/spotify_song_list_provider.dart
+++ b/lib/resources/spotify/spotify_song_list_provider.dart
@@ -213,6 +213,8 @@ class SpotifySongListProvider extends SongListProvider {
   }
 
   void _getTokenFromSDK() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (_clientID == "invalid") _clientID = prefs.getString('clientID');
     final String token = await SpotifySdk.getAccessToken(
       clientId: _clientID!,
       redirectUrl: _redirectUrl!,


### PR DESCRIPTION
In theory this should allow sideloading under iOS again (and sideloading of modified androis apks, idk if anyone wants to do that).
sideloading.md explains how retro can be built to enable this.

Technical info: The spotify API requires you to enter a bundle ID, but free developer accounts can't use bundle ids that already got published either onto the appstore or testflight. With this patch, an user could sideload retro, create spotify api keys for their personal bundle id and then enter them into our onboarding assistent.
Not pretty (yet) but functional and ideally the user only sees this menu once.

fixes #41 